### PR TITLE
SAGE-1576: Added support for head queries.

### DIFF
--- a/src/sage_data_client/query.py
+++ b/src/sage_data_client/query.py
@@ -15,7 +15,7 @@ def timestr(t):
     return t.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
 
 
-def query(start, end = None, tail: int = None, bucket: str = None, filter: dict = None,
+def query(start, end = None, head: int = None, tail: int = None, bucket: str = None, filter: dict = None,
     endpoint: str = "https://data.sagecontinuum.org/api/v1/query") -> pd.DataFrame:
     """
     query makes a query request to the data API and returns the results in a data frame.
@@ -28,7 +28,9 @@ def query(start, end = None, tail: int = None, bucket: str = None, filter: dict 
     end : query end time, default: None
         Timestamps can be a relative like "-1h" or absolute like "2021-05-01T10:30:00Z".
 
-    tail : limit query response to latest tail records, default: None
+    head : limit query response to earliest `head` records, default: None (only one of `head` or `tail` can be provided)
+
+    tail : limit query response to latest `tail` records, default: None (only one of `head` or `tail` can be provided)
 
     bucket: name of bucket to query
 
@@ -75,6 +77,10 @@ def query(start, end = None, tail: int = None, bucket: str = None, filter: dict 
         q["end"] = timestr(resolve_time(end))
     if filter is not None:
         q["filter"] = filter
+    if head is not None and tail is not None:
+        raise ValueError("only one of `head` or `tail` can be provided")
+    if head is not None:
+        q["head"] = head
     if tail is not None:
         q["tail"] = tail
     if bucket is not None:

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -21,6 +21,17 @@ class TestQuery(unittest.TestCase):
             "name": "should.not.every.exist.XYZ",
         }))
 
+    def test_check_one_of_head_or_tail(self):
+        with self.assertRaises(ValueError):
+            sage_data_client.query(
+                start="2021-01-01T10:30:00",
+                end="2021-01-01T10:31:00",
+                head=3,
+                tail=3,
+                filter={
+                    "name": "env.temperature",
+            })
+
     def test_queries(self):
         self.assertValueResponse(sage_data_client.query(
             start="2021-01-01T10:30:00",


### PR DESCRIPTION
This PR adds the `head` param to `query` which allows for querying the earliest `head` items from each group of results.